### PR TITLE
Feature/limit updates to latest tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet
+FROM microsoft/dotnet:2.1-runtime
 WORKDIR /app
 COPY ./out .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:2.1-runtime
+FROM microsoft/dotnet:2.1-aspnetcore-runtime
 WORKDIR /app
 COPY ./out .
 
-ARG KUBECTL_VERSION="1.7.2"
+ARG KUBECTL_VERSION="1.10.2"
 
 RUN apt-get update && \
     apt-get install -y curl openssh-client && \

--- a/Domain/AppSettings.cs
+++ b/Domain/AppSettings.cs
@@ -1,0 +1,7 @@
+namespace Updater.Domain
+{
+    public class AppSettings
+    {
+        public string UpdateTagsMatching { get; set; }
+    }
+}

--- a/Domain/ImageUpdaterTests.cs
+++ b/Domain/ImageUpdaterTests.cs
@@ -17,7 +17,7 @@ namespace Updater.Domain
         public void WhenValidJsonIsRespondedFromCtl_ThenInvokeUpdateCommandsCorretly()
         {
             var shell = Substitute.For<ICommandLine>();
-            var updater = new ImageUpdater(shell, Substitute.For<ILogger<ImageUpdater>>(), TestUtils.CreateInMemoryContext(), TestUtils.GetAppSettings());
+            var updater = new ImageUpdater(shell, Substitute.For<ILogger<ImageUpdater>>(), TestUtils.CreateInMemoryContext(), TestUtils.GetAppSettings(".*master.*"));
 
             shell.Run(Arg.Any<string>()).Returns("result".Some<string, Exception>());
             shell.Run("kubectl get deployments --all-namespaces -o json")

--- a/Domain/ImageUriParserTests.cs
+++ b/Domain/ImageUriParserTests.cs
@@ -55,7 +55,7 @@ namespace Updater.Domain
         public void WhenParsesInvalidFormatOfUri_ThenThrowError()
         {
             Action test = () => ImageUriParser.ParseUri(":sometag");
-            test.ShouldThrow<ArgumentException>();
+            test.Should().Throw<ArgumentException>();
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -13,18 +13,6 @@ namespace Updater
 
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .ConfigureAppConfiguration((builderContext, config) =>
-                {
-                    IHostingEnvironment env = builderContext.HostingEnvironment;
-
-                    config
-                        .SetBasePath(env.ContentRootPath)
-                        .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-                        .AddJsonFile($"appsettings.localdev.json", optional: true)
-                        .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
-                        .AddJsonFile($"./config/appsettings.{env.EnvironmentName}.json", true)
-                        .AddEnvironmentVariables();
-                })
                 .UseStartup<Startup>()
                 .UseUrls("http://0.0.0.0:5000")
                 .Build();

--- a/Startup.cs
+++ b/Startup.cs
@@ -28,6 +28,8 @@ namespace Updater
         {
             services.AddDbContext<UpdaterDbContext>(options => options.UseInMemoryDatabase(databaseName: "db"));
             services.AddTransient<ImageUpdater>();
+            services.Configure<AppSettings>(Configuration);
+
             services.AddMvc(options =>
             {
                 options.Filters.Add(new ValidateModelAttribute());

--- a/Updater.csproj
+++ b/Updater.csproj
@@ -1,22 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="FluentAssertions" Version="5.4.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="Protacon.NetCore.WebApi.ApiKeyAuth" Version="2.0.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="1.1.0" />
-    <PackageReference Include="Optional" Version="4.0.0-rc" />
-    <PackageReference Include="Protacon.NetCore.WebApi.Util" Version="0.0.3" />
-  </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="2.5.0" />
+    <PackageReference Include="Optional" Version="4.0.0" />
+    <PackageReference Include="Protacon.NetCore.WebApi.Util" Version="0.0.4" />
   </ItemGroup>
 </Project>

--- a/Util/TestExtensions.cs
+++ b/Util/TestExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Updater.Domain;
 
@@ -16,6 +17,11 @@ namespace Updater.Util
                 Arg.Any<object>(),
                 null,
                 Arg.Any<Func<object, Exception, string>>());
+        }
+
+        public static IOptions<AppSettings> GetAppSettings(string imageTagValidator = ".*")
+        {
+            return Options.Create(new AppSettings() { UpdateTagsMatching = imageTagValidator });
         }
 
         public static UpdaterDbContext CreateInMemoryContext()

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,3 +1,4 @@
 {
-   "apiKeys": ["apikeyfortesting"]
+   "apiKeys": ["apikeyfortesting"],
+   "UpdateTagsMatching": ".*latest.*"
 }


### PR DESCRIPTION
This is software which makes magic that during build images are updated to test environment with newest images without further configuration like target namespaces or deployments.

Theres "non latest" images around test environment and then theres latest. Latest is hint that image should be last development version and other tags should stay as they are. Current version overwrite any matching image with new one, this version allows limit targeted tags by regex. Likely it should be something like ".*latest.*".

